### PR TITLE
Add cloudtrail integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ venv
 *.pyc
 *.log
 htmlcov
+.coverage
+.cache
 

--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ You're ready to go!
 #### Unit-testing
 
 ```
-python -m unittests
+py.test tests/
 ```
 
 #### Fake Log Generator

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ def connect_to_amqp():
     yield amqp_con.declare_queue("mobile_production_queue")
     yield amqp_con.declare_queue("heroku_integration_queue")
     yield amqp_con.declare_queue("heroku_production_queue")
+    yield amqp_con.declare_queue("cloudtrail_production_queue")
     return amqp_con
 
 amqp_con = IOLoop.current().run_sync(connect_to_amqp)
@@ -28,6 +29,7 @@ amqp_con = IOLoop.current().run_sync(connect_to_amqp)
 app = tornado.web.Application([
     (r"/heroku/.*", HerokuHandler, dict(amqp_con=amqp_con)),
     (r"/mobile/.*", MobileHandler, dict(amqp_con=amqp_con)),
+    (r"/cloudtrail/.*", CloudTrailHandler, dict(amqp_con=amqp_con)),
     (r"/api/healthcheck", HeartbeatHandler),
     (r"/api/heartbeat", HeartbeatHandler),
    ])

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import sys
 from src.handlers.heartbeat import HeartbeatHandler
 from src.handlers.heroku import HerokuHandler
 from src.handlers.mobile import MobileHandler
+from src.handlers.cloudtrail import CloudTrailHandler
 
 from src.lib.AMQPConnection import AMQPConnection
 

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ def connect_to_amqp():
     yield amqp_con.declare_queue("mobile_production_queue")
     yield amqp_con.declare_queue("heroku_integration_queue")
     yield amqp_con.declare_queue("heroku_production_queue")
+    yield amqp_con.declare_queue("cloudtrail_integration_queue")
     yield amqp_con.declare_queue("cloudtrail_production_queue")
     return amqp_con
 

--- a/src/handlers/cloudtrail.py
+++ b/src/handlers/cloudtrail.py
@@ -2,6 +2,7 @@ import tornado.web
 import logging
 import sys
 import gzip
+import json
 
 from src.lib.Statsd import StatsClientSingleton
 
@@ -33,7 +34,9 @@ class CloudTrailHandler(tornado.web.RequestHandler):
             if content_encoding == 'gzip':
                 payload = gzip.decompress(payload)
 
-            self.amqp_con.publish(routing_key, payload)
+            entry_list = json.loads(payload)["Records"]
+            for entry in entry_list:
+                self.amqp_con.publish(routing_key, json.dumps(entry))
 
         except Exception as e:
             self.set_status(500)

--- a/src/handlers/cloudtrail.py
+++ b/src/handlers/cloudtrail.py
@@ -25,8 +25,7 @@ class CloudTrailHandler(tornado.web.RequestHandler):
         :return: HTTPStatus 200
         """
         try:
-            StatsClientSingleton().incr('input.cloudtrail', count=1)
-            StatsClientSingleton().incr('amqp.output', count=1)
+            StatsClientSingleton().incr('cloudtrail.input', count=1)
             routing_key = self.request.uri.replace('/', '.')[1:]
 
             payload = self.request.body
@@ -37,6 +36,8 @@ class CloudTrailHandler(tornado.web.RequestHandler):
             entry_list = json.loads(payload)["Records"]
             for entry in entry_list:
                 self.amqp_con.publish(routing_key, json.dumps(entry))
+
+            StatsClientSingleton().incr('amqp.output', count=len(entry_list))
 
         except Exception as e:
             self.set_status(500)

--- a/src/handlers/cloudtrail.py
+++ b/src/handlers/cloudtrail.py
@@ -33,7 +33,7 @@ class CloudTrailHandler(tornado.web.RequestHandler):
             if content_encoding == 'gzip':
                 payload = gzip.decompress(payload)
 
-            entry_list = json.loads(payload)["Records"]
+            entry_list = json.loads(payload.decode())["Records"]
             for entry in entry_list:
                 self.amqp_con.publish(routing_key, json.dumps(entry))
 

--- a/src/handlers/cloudtrail.py
+++ b/src/handlers/cloudtrail.py
@@ -6,8 +6,8 @@ import gzip
 from src.lib.Statsd import StatsClientSingleton
 
 
-class MobileHandler(tornado.web.RequestHandler):
-    """ The Mobile HTTP handler class
+class CloudTrailHandler(tornado.web.RequestHandler):
+    """ The AWS CloudTrail handler class
     """
 
     def initialize(self, amqp_con):
@@ -24,7 +24,7 @@ class MobileHandler(tornado.web.RequestHandler):
         :return: HTTPStatus 200
         """
         try:
-            StatsClientSingleton().incr('input.mobile', count=1)
+            StatsClientSingleton().incr('input.cloudtrail', count=1)
             StatsClientSingleton().incr('amqp.output', count=1)
             routing_key = self.request.uri.replace('/', '.')[1:]
 
@@ -38,7 +38,7 @@ class MobileHandler(tornado.web.RequestHandler):
         except Exception as e:
             self.set_status(500)
             StatsClientSingleton().incr('amqp.output_exception', count=1)
-            self.logger.info("Error while pushing mobile message to AMQP, "
+            self.logger.info("Error while pushing CloudTrail message to AMQP, "
                              "exception: {} msg: {}, uri: {}"
                              .format(e, self.request.body, self.request.uri))
             sys.exit(1)

--- a/tests/handlers/test_cloudtrail.py
+++ b/tests/handlers/test_cloudtrail.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from src.handlers.cloudtrail import CloudTrailHandler
+
+
+class TestHeroku(unittest.TestCase):
+
+    @patch('src.handlers.heroku.sys.exit')
+    def test_h2l_heroku_post_failure(self, sysExit):
+        """
+        Exception occurs while pushing message to rabbitmq
+        return 500
+        :return:
+        """
+
+        sysExit = Mock(return_value=True)
+        amqp_con = Mock()
+        amqp_con.publish = Mock(side_effect=Exception)
+        application = Mock()
+        application.ui_methods = Mock()
+        application.ui_methods.items = Mock(return_value=[])
+        request = Mock()
+        request.uri = "./heroku/v1/integration/toto"
+        handler = CloudTrailHandler(application, request, amqp_con=amqp_con)
+
+        handler.request.body = b"123 <40>1 2017-06-21T17:02:55+00:00 host ponzi web.1 - " \
+            b"Lorem ipsum dolor sit amet, consecteteur adipiscing elit b'quis' b'ad'.\n"
+
+        handler.post()
+
+        handler.get_status()
+        self.assertEqual(handler.get_status(), 500)

--- a/tests/handlers/test_cloudtrail.py
+++ b/tests/handlers/test_cloudtrail.py
@@ -4,10 +4,10 @@ from unittest.mock import Mock, patch
 from src.handlers.cloudtrail import CloudTrailHandler
 
 
-class TestHeroku(unittest.TestCase):
+class TestCloudTrail(unittest.TestCase):
 
     @patch('src.handlers.heroku.sys.exit')
-    def test_h2l_heroku_post_failure(self, sysExit):
+    def test_h2l_cloudtrail_post_failure(self, sysExit):
         """
         Exception occurs while pushing message to rabbitmq
         return 500
@@ -21,11 +21,10 @@ class TestHeroku(unittest.TestCase):
         application.ui_methods = Mock()
         application.ui_methods.items = Mock(return_value=[])
         request = Mock()
-        request.uri = "./heroku/v1/integration/toto"
+        request.uri = "./cloudtrail/v1/integration/toto"
         handler = CloudTrailHandler(application, request, amqp_con=amqp_con)
 
-        handler.request.body = b"123 <40>1 2017-06-21T17:02:55+00:00 host ponzi web.1 - " \
-            b"Lorem ipsum dolor sit amet, consecteteur adipiscing elit b'quis' b'ad'.\n"
+        handler.request.body = '{"test": "plop"}'
 
         handler.post()
 

--- a/tests/handlers/test_cloudtrail_tornado.py
+++ b/tests/handlers/test_cloudtrail_tornado.py
@@ -31,7 +31,7 @@ class TestTornadoCloudTrail(AsyncHTTPTestCase):
         yield consumer.connect(self.io_loop)
 
         self.futureMsg = Future()
-        yield consumer.subscribe("cloudtrail.v1.integration.toto", "cloudtrail_queue", self.on_message)
+        yield consumer.subscribe("cloudtrail.v1.integration.toto", "cloudtrail_integration_queue", self.on_message)
 
         payload = b'{"Records": [{"test": "plop"}]}'
         response = self.http_client.fetch(
@@ -55,7 +55,7 @@ class TestTornadoCloudTrail(AsyncHTTPTestCase):
         yield consumer.connect(self.io_loop)
 
         self.futureMsg = Future()
-        yield consumer.subscribe("cloudtrail.v1.integration.toto", "cloudtrail_queue", self.on_message)
+        yield consumer.subscribe("cloudtrail.v1.integration.toto", "cloudtrail_integration_queue", self.on_message)
 
         payload = gzip.compress(json.dumps({'Records': [{'message': 'this is a log message'}]}).encode())
 

--- a/tests/handlers/test_cloudtrail_tornado.py
+++ b/tests/handlers/test_cloudtrail_tornado.py
@@ -1,0 +1,83 @@
+import json
+import gzip
+import tornado
+from tornado import gen
+from tornado.ioloop import IOLoop
+from tornado.concurrent import Future
+from tornado.testing import AsyncHTTPTestCase, gen_test
+
+from src.handlers.cloudtrail import CloudTrailHandler
+from src.lib.AMQPConnection import AMQPConnection
+
+
+@gen.coroutine
+def connect_to_amqp():
+    amqp_con = AMQPConnection()
+    yield amqp_con.connect(IOLoop.current())
+    return amqp_con
+
+
+class TestTornadoCloudTrail(AsyncHTTPTestCase):
+    def get_app(self):
+        con = self.io_loop.run_sync(connect_to_amqp)
+        return tornado.web.Application([(r"/cloudtrail/.*", CloudTrailHandler, dict(amqp_con=con))])
+
+    def setUp(self):
+        super(TestTornadoCloudTrail, self).setUp()
+
+    @gen_test
+    def test_cloudtrail_push_to_amqp_success(self):
+        consumer = AMQPConnection()
+        yield consumer.connect(self.io_loop)
+
+        self.futureMsg = Future()
+        yield consumer.subscribe("cloudtrail.v1.integration.toto", "cloudtrail_queue", self.on_message)
+
+        payload = b"123 <40>1 2017-06-21T17:02:55+00:00 host ponzi web.1 - " \
+                  b"Lorem ipsum dolor sit amet, consecteteur adipiscing elit b'quis' b'ad'.\n"
+        response = self.http_client.fetch(
+            self.get_url('/cloudtrail/v1/integration/toto'),
+            method='POST',
+            body=payload,
+            use_gzip=False
+        )
+
+        res = yield self.futureMsg
+        self.assertEqual(res, b"123 <40>1 2017-06-21T17:02:55+00:00 host ponzi web.1 - "
+                              b"Lorem ipsum dolor sit amet, consecteteur adipiscing elit b'quis' b'ad'.\n")
+        value = yield response
+        self.assertEqual(value.code, 200)
+        self.assertEqual(len(value.body), 0)
+
+        yield consumer.disconnect()
+
+    @gen_test
+    def test_cloudtrail_push_to_amqp_success_gzip(self):
+        consumer = AMQPConnection()
+        yield consumer.connect(self.io_loop)
+
+        self.futureMsg = Future()
+        yield consumer.subscribe("cloudtrail.v1.integration.toto", "cloudtrail_queue", self.on_message)
+
+        payload = gzip.compress(json.dumps({'message': 'this is a log message'}).encode())
+
+        request = tornado.httpclient.HTTPRequest(
+            self.get_url('/cloudtrail/v1/integration/toto'),
+            method='POST',
+            body=payload,
+            use_gzip=True)
+
+        response = self.http_client.fetch(request)
+
+        res = yield self.futureMsg
+        self.assertEqual(res, b'{"message": "this is a log message"}')
+        value = yield response
+        self.assertEqual(value.code, 200)
+        self.assertEqual(len(value.body), 0)
+
+        yield consumer.disconnect()
+
+    def on_message(self, channel, basic_deliver, properties, body):
+        if not self.futureMsg.done():
+            self.futureMsg.set_result(body)
+        channel.basic_ack(basic_deliver.delivery_tag)

--- a/tests/handlers/test_cloudtrail_tornado.py
+++ b/tests/handlers/test_cloudtrail_tornado.py
@@ -33,8 +33,7 @@ class TestTornadoCloudTrail(AsyncHTTPTestCase):
         self.futureMsg = Future()
         yield consumer.subscribe("cloudtrail.v1.integration.toto", "cloudtrail_queue", self.on_message)
 
-        payload = b"123 <40>1 2017-06-21T17:02:55+00:00 host ponzi web.1 - " \
-                  b"Lorem ipsum dolor sit amet, consecteteur adipiscing elit b'quis' b'ad'.\n"
+        payload = b'{"Records": [{"test": "plop"}]}'
         response = self.http_client.fetch(
             self.get_url('/cloudtrail/v1/integration/toto'),
             method='POST',
@@ -43,8 +42,7 @@ class TestTornadoCloudTrail(AsyncHTTPTestCase):
         )
 
         res = yield self.futureMsg
-        self.assertEqual(res, b"123 <40>1 2017-06-21T17:02:55+00:00 host ponzi web.1 - "
-                              b"Lorem ipsum dolor sit amet, consecteteur adipiscing elit b'quis' b'ad'.\n")
+        self.assertEqual(res, b'{"test": "plop"}')
         value = yield response
         self.assertEqual(value.code, 200)
         self.assertEqual(len(value.body), 0)
@@ -59,7 +57,7 @@ class TestTornadoCloudTrail(AsyncHTTPTestCase):
         self.futureMsg = Future()
         yield consumer.subscribe("cloudtrail.v1.integration.toto", "cloudtrail_queue", self.on_message)
 
-        payload = gzip.compress(json.dumps({'message': 'this is a log message'}).encode())
+        payload = gzip.compress(json.dumps({'Records': [{'message': 'this is a log message'}]}).encode())
 
         request = tornado.httpclient.HTTPRequest(
             self.get_url('/cloudtrail/v1/integration/toto'),

--- a/tests/handlers/test_mobile.py
+++ b/tests/handlers/test_mobile.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 from src.handlers.mobile import MobileHandler
 
 
-class TestHeroku(unittest.TestCase):
+class TestMobile(unittest.TestCase):
 
     @patch('src.handlers.heroku.sys.exit')
     def test_h2l_heroku_post_failure(self, sysExit):


### PR DESCRIPTION
This PR adds support for AWS CloudTrail logs.
You need to POST it the CloudTrail log file, then it will separate the messages and send each of them in RabbitMQ.