### PR TITLE
TECH Remove Heroku queues references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ venv
 htmlcov
 .coverage
 .cache
-
+.idea/*

--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -1,4 +1,4 @@
-input { 
+input {
 	rabbitmq {
 		host => "localhost"
 		queue => "heroku_production_queue"
@@ -83,8 +83,6 @@ input {
 		}
 	}
 }
-
-
 
 filter {
     grok {

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from tornado.ioloop import IOLoop
 import sys
 
 from src.handlers.heartbeat import HeartbeatHandler
-from src.handlers.heroku import HerokuHandler
+# from src.handlers.heroku import HerokuHandler
 from src.handlers.mobile import MobileHandler
 from src.handlers.cloudtrail import CloudTrailHandler
 
@@ -19,8 +19,8 @@ def connect_to_amqp():
         sys.exit(1)
     yield amqp_con.declare_queue("mobile_integration_queue")
     yield amqp_con.declare_queue("mobile_production_queue")
-    yield amqp_con.declare_queue("heroku_integration_queue")
-    yield amqp_con.declare_queue("heroku_production_queue")
+    # yield amqp_con.declare_queue("heroku_integration_queue")
+    # yield amqp_con.declare_queue("heroku_production_queue")
     yield amqp_con.declare_queue("cloudtrail_integration_queue")
     yield amqp_con.declare_queue("cloudtrail_production_queue")
     return amqp_con
@@ -29,7 +29,7 @@ amqp_con = IOLoop.current().run_sync(connect_to_amqp)
 
 
 app = tornado.web.Application([
-    (r"/heroku/.*", HerokuHandler, dict(amqp_con=amqp_con)),
+    # (r"/heroku/.*", HerokuHandler, dict(amqp_con=amqp_con)),
     (r"/mobile/.*", MobileHandler, dict(amqp_con=amqp_con)),
     (r"/cloudtrail/.*", CloudTrailHandler, dict(amqp_con=amqp_con)),
     (r"/api/healthcheck", HeartbeatHandler),


### PR DESCRIPTION
- Remove references to Heroku's queues since we don't use Heroku any more.
- Update .gitignore